### PR TITLE
Enable test.pypi.org upload action for dev/cov2_mpire branch

### DIFF
--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -2,7 +2,7 @@ name: TestPyPI
 on:
   push:
     branches:
-      - feature/packageandtest
+      - dev/cov2_mpire
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Enable the github action that uploads each commit to the dev/cov2_mpire branch to test.pypi.org. This will ensure that we are always ready to do a real release to pypi.org from code that is in this branch.