### PR TITLE
Add missing newline to end of paranoid alignment output

### DIFF
--- a/src/covsonar/cache.py
+++ b/src/covsonar/cache.py
@@ -668,6 +668,7 @@ class sonarCache:
                                     + sample_data["name"]
                                     + "\n"
                                     + qry
+                                    + "\n"
                                 )
                             sys.exit(
                                 "import error: original sequence of sample "


### PR DESCRIPTION
Unix files should have newlines at the end of them. Added this missing newline to the end of the paranoid.alignment.fna file.