### PR TITLE
Add mamba to GitHub actions environments, so testing works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,22 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
       with:
         python-version: '3.9'
         architecture: x64
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        python-version: 3.9
+        mamba-version: "*"
+        activate-environment: covsonar
+        channels: conda-forge,bioconda,defaults
+        channel-priority: true
     - run: pip install nox==2022.1.7
     - run: pip install poetry==1.1.13
     - run: nox

--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -6,12 +6,22 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
       with:
         python-version: '3.9'
         architecture: x64
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        python-version: 3.9
+        mamba-version: "*"
+        activate-environment: covsonar
+        channels: conda-forge,bioconda,defaults
+        channel-priority: true
     - run: pip install nox==2022.1.7
     - run: pip install poetry==1.1.13
     - run: nox


### PR DESCRIPTION
EMBOSS/stretcher is needed by the automated tests now. This means that mamba is needed in all GitHub actions that run the full test suite via nox. Added it to the two actions that push to test.pypi.org and pypi.org.