### PR TITLE
Update Feature/note/cov2_mpire

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Genomic profiles can be defined to align genomes. For this purpose, the variants
 | type       | nucleotide level                                                  | amino acid level              |
 |-----------|-------------------------------------------------------------------|-------------------------------|
 | SNP       | ref_nuc _followed by_ ref_pos _followed by_ alt_nuc (e.g. A3451T) | protein_symbol:ref_aa _followed by_ ref_pos _followed by_ alt_aa (e.g. S:N501Y) |
-| deletion  | del:ref_pos:length_in_bp (e.g. del:3001:8)                        | protein_symbol:del:ref_pos:length_in_aa (e.g. ORF1ab:del:3001:21) |
+| deletion  | del:first_NT_deleted-last_NT_deleted (e.g. del:11288-11296)                        | protein_symbol:del:first_AA_deleted-last_AA_deleted (e.g. ORF1ab:del:3001-3004) |
 | insertion | ref_nuc _followed by_ ref_pos _followed by_ alt_nucs (e.g. A3451TGAT) | protein_symbol:ref_aa _followed by_ ref_pos _followed by_ alt_aas (e.g. N:A34AK)  |
 
 The positions refer to the reference (first nucleotide in the genome is position 1). Using the option `--profile`, multiple variant definitions can be combined into a nucleotide, amino acid or mixed profile, which means that matching genomes must have all those variations in common. In contrast, alternative variations can be defined by multiple `--profile` options. As an example, `--profile S:N501Y S:E484K` matches genomes sharing the _Nelly_ **AND** _Erik_ variation while `--profile S:N501Y --profile S:E484K` matches to genomes that share either the _Nelly_ **OR** _Erik_ variation **OR** both. Accordingly, using the option **^** profiles can be defined that have not to be present in the matched genomes.
@@ -226,6 +226,36 @@ We use `^` as a **"NOT"** operator. We put it before any conditional statement t
 # matching genomes in DB 'mydb' sharing the "Nelly" and the "Erik" mutation but not
 # belonging to the B.1.1.7 lineage
 sonar match -profile S:N501Y S:E484K --LINEAGE ^B.1.1.7 --db test.db
+
+```
+
+More example; `--profile` match
+```sh
+# AA profile OR  NT profile case
+sonar match --profile S:del:K418I --profile T418A  --db test.db
+# AA profile AND NT profile case
+sonar match --profile S:del:K418I del:3677-3677  --db test.db
+# exact Match X or N , we use small x for AA and small n for NT
+sonar match --profile S:K418x --db test.db
+# this will match S:K418X
+
+sonar match --profile A2145n --db test.db
+# this will match A2145N
+
+# speacial case, we can combine exact match and any match in alternate postion.
+sonar match  --profile A2145nN --db test.db
+# this will look in ('NG', 'NB', 'NT', 'NM', 'NS', 'NV', 'NA', 'NH',
+# 'ND', 'NY', 'NR', 'NW', 'NK', 'NN', 'NC')
+
+```
+
+More example; property match
+```sh
+# int
+
+# zip code
+
+# date
 
 ```
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -338,6 +338,14 @@ pytz = ">=2020.1"
 test = ["hypothesis (>=5.5.3)", "pytest (>=6.0)", "pytest-xdist (>=1.31)"]
 
 [[package]]
+name = "pango-aliasor"
+version = "0.1.4"
+description = "Pango lineage aliasing and dealiasing"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "pathspec"
 version = "0.9.0"
 description = "Utility library for gitignore style pattern matching of file paths."
@@ -675,7 +683,7 @@ tomli = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "df5dd29b606651ee0366d99b33ed833b0d936ea8c2c88bc03d313da794d189f3"
+content-hash = "9cab5ad7d9952dae076636342295283a1cd8c205615dab5e583af43e706e998d"
 
 [metadata.files]
 atomicwrites = []
@@ -706,6 +714,7 @@ mypy-extensions = []
 numpy = []
 packaging = []
 pandas = []
+pango-aliasor = []
 pathspec = []
 pbr = []
 platformdirs = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ tabulate = "~0.8.9"
 mpire = "~2.3.3"
 pandas = "~1.4.0"
 requests = "^2.28.0"
+pango-aliasor = "^0.1.4"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"

--- a/src/covsonar/linmgr.py
+++ b/src/covsonar/linmgr.py
@@ -12,13 +12,64 @@ from tempfile import mkdtemp
 import pandas as pd
 import requests
 
-try:
+from . import logging
+
+try:  # noqa: C901
     from pango_aliasor.aliasor import Aliasor
-except ModuleNotFoundError as e:
-    print(
+except ModuleNotFoundError:  # pragma: no cover
+    logging.WARN(
         "Dependency `pango_aliasor` missing, please install using `pip install pango_aliasor`"
     )
-    raise e
+    logging.WARN("Fall back to original Aliasor...")
+
+    class Aliasor:
+        def __init__(self, alias_file=None):
+            import json
+
+            if alias_file is None:
+                import importlib.resources
+
+                with importlib.resources.open_text(
+                    "pango_designation", "alias_key.json"
+                ) as file:
+                    file = json.load(file)
+
+            else:
+                with open(alias_file) as file:
+                    file = json.load(file)
+
+            self.alias_dict = {}
+            for column in file.keys():
+                if type(file[column]) is list or file[column] == "":
+                    self.alias_dict[column] = column
+                else:
+                    self.alias_dict[column] = file[column]
+
+            self.realias_dict = {v: k for k, v in self.alias_dict.items()}
+
+        def compress(self, name):
+            name_split = name.split(".")
+            levels = len(name_split) - 1
+            num_indirections = (levels - 1) // 3
+            if num_indirections <= 0:
+                return name
+            alias = ".".join(name_split[0 : (3 * num_indirections + 1)])
+            ending = ".".join(name_split[(3 * num_indirections + 1) :])
+            return self.realias_dict[alias] + "." + ending
+
+        def uncompress(self, name):
+            name_split = name.split(".")
+            letter = name_split[0]
+            try:
+                unaliased = self.alias_dict[letter]
+            except KeyError:
+                return name
+            if len(name_split) == 1:
+                return name
+            if len(name_split) == 2:
+                return unaliased + "." + name_split[1]
+            else:
+                return unaliased + "." + ".".join(name_split[1:])
 
 
 class sonarLinmgr:

--- a/src/covsonar/linmgr.py
+++ b/src/covsonar/linmgr.py
@@ -12,37 +12,13 @@ from tempfile import mkdtemp
 import pandas as pd
 import requests
 
-
-class Aliasor:
-    def __init__(self, alias_file):
-        aliases = pd.read_json(alias_file)
-        self.alias_dict = {
-            x: x if x.startswith("X") else aliases[x][0] for x in aliases.columns
-        }
-        self.alias_dict["A"] = "A"
-        self.alias_dict["B"] = "B"
-        self.realias_dict = {v: k for k, v in self.alias_dict.items()}
-
-    def compress(self, name):
-        name_split = name.split(".")
-        if len(name_split) < 5:
-            return name
-        letter = self.realias_dict[".".join(name_split[0:4])]
-        if len(name_split) == 5:
-            return letter + "." + name_split[4]
-        else:
-            return letter + "." + ".".join(name_split[4:])
-
-    def uncompress(self, name):
-        name_split = name.split(".")
-        letter = name_split[0]
-        unaliased = self.alias_dict[letter]
-        if len(name_split) == 1:
-            return name
-        if len(name_split) == 2:
-            return unaliased + "." + name_split[1]
-        else:
-            return unaliased + "." + ".".join(name_split[1:])
+try:
+    from pango_aliasor.aliasor import Aliasor
+except ModuleNotFoundError as e:
+    print(
+        "Dependency `pango_aliasor` missing, please install using `pip install pango_aliasor`"
+    )
+    raise e
 
 
 class sonarLinmgr:
@@ -79,16 +55,6 @@ class sonarLinmgr:
         return "".join(items)
 
     def process_lineage_data(self, output_file):
-        # handle duplicate values
-        with open(self.alias_file) as f:
-            # load json objects to dictionaries
-            data_dict = json.load(f)
-        for k, v in data_dict.items():
-            if type(v) is list:
-                data_dict[k] = list(set(v))
-        # rewrite the json
-        with open(self.alias_file, "w") as nf:
-            json.dump(data_dict, nf)
 
         aliasor = Aliasor(self.alias_file)
         df_lineages = pd.read_csv(self.lineage_file)
@@ -98,27 +64,38 @@ class sonarLinmgr:
         sorted_lineages = []
 
         # Calculating parent-child relationship
-        uncompressed_lineages = [x for x in map(aliasor.uncompress, lineages)]
+        uncompressed_lineages = list(map(aliasor.uncompress, lineages))
         uncompressed_lineages.sort(key=sonarLinmgr.lts)
-        sorted_lineages = [x for x in map(aliasor.compress, uncompressed_lineages)]
+        sorted_lineages = list(map(aliasor.compress, uncompressed_lineages))
 
-        datadict = []
-        for _id in lineages:
-            sub_lineage_char = aliasor.realias_dict.get(_id)
-            sub_lineage_list = [
-                x for x in sorted_lineages if x.split(".")[0] == sub_lineage_char
-            ]
-            sub_lineage_list = list(filter((_id).__ne__, sub_lineage_list))
-            if len(sub_lineage_list):
-                datadict.append(
-                    {"lineage": _id, "sublineage": ",".join(sub_lineage_list)}
-                )
+        _final_list = []
+        for _id in sorted_lineages:
+            alias_lineage_char = aliasor.uncompress(_id)
+            sub_lineage_list = []
+            row_dict = {}
+            # print(_id, '=',alias_lineage_char)
+
+            for name_ in uncompressed_lineages:  # fetch all lineage again
+                root = ""
+                for index, letter in enumerate(name_.split(".")):
+                    if index != 0:
+                        letter = root + "." + letter
+                    root = letter
+                    if letter == alias_lineage_char:
+                        sub_lineage_list.append(aliasor.compress(name_))
+            # remove root lineage
+            sub_lineage_list.remove(_id)
+            if len(sub_lineage_list) > 0:
+                row_dict["lineage"] = _id
+                row_dict["sublineage"] = ",".join(sub_lineage_list)
             else:
-                datadict.append({"lineage": _id, "sublineage": "none"})
+                row_dict["lineage"] = _id
+                row_dict["sublineage"] = "none"
+            _final_list.append(row_dict)
 
-        return pd.DataFrame(
-            datadict
-        )  # pd.DataFrame(datadict).to_csv(output_file, sep="	", index=False)
+        df = pd.DataFrame.from_dict(_final_list, orient="columns")
+
+        return df.sort_values(by=["lineage"])
 
     def update_lineage_data(self, output_file):
         self.download_lineage_data()


### PR DESCRIPTION
- Add [pango_aliasor package](https://github.com/corneliusroemer/pango_aliasor) 
- Add exact search (#26); we use small n and x to create an exact match 
```
sonar match --profile S:K418x --db test.db
# this will match S:K418X

sonar match --profile A2145n --db test.db
# this will match A2145N

sonar match --profile S:K418x --db test.db
# this will match S:K418X

# we can combine the exact match and any match in alternate positions.
sonar match  --profile A2145nN --db test.db
# this will look in ('NG', 'NB', 'NT', 'NM', 'NS', 'NV', 'NA', 'NH',
# 'ND', 'NY', 'NR', 'NW', 'NK', 'NN', 'NC')
``` 
- Update the parent-child function now it should produce the correct result
- Fix minor bugs 