### PR TITLE
zimports: split imports over multiple lines

### DIFF
--- a/src/covsonar/align.py
+++ b/src/covsonar/align.py
@@ -6,7 +6,12 @@ import os
 import pickle
 import re
 import sys
-from typing import Dict, Generator, List, Optional, Pattern, Tuple
+from typing import Dict
+from typing import Generator
+from typing import List
+from typing import Optional
+from typing import Pattern
+from typing import Tuple
 
 import pandas as pd
 import parasail

--- a/src/covsonar/cache.py
+++ b/src/covsonar/cache.py
@@ -13,7 +13,14 @@ import shutil
 import sys
 from tempfile import mkdtemp
 from tempfile import TemporaryDirectory
-from typing import Any, DefaultDict, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any
+from typing import DefaultDict
+from typing import Dict
+from typing import Iterator
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Union
 
 import pandas as pd
 from tqdm import tqdm

--- a/src/covsonar/dbm.py
+++ b/src/covsonar/dbm.py
@@ -6,11 +6,19 @@ import pkgutil
 import re
 import sqlite3
 import sys
-from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Union
+from typing import Any
+from typing import Dict
+from typing import Iterator
+from typing import List
+from typing import Optional
+from typing import Set
+from typing import Tuple
+from typing import Union
 from urllib.parse import quote as urlquote
 
 from Bio.Seq import Seq
-from Bio.SeqFeature import CompoundLocation, FeatureLocation
+from Bio.SeqFeature import CompoundLocation
+from Bio.SeqFeature import FeatureLocation
 import pandas as pd
 import sqlparse
 

--- a/src/covsonar/logging.py
+++ b/src/covsonar/logging.py
@@ -1,7 +1,8 @@
 import configparser
 import logging
 import sys
-from typing import Dict, Optional
+from typing import Dict
+from typing import Optional
 
 
 class LoggingConfigurator:

--- a/src/covsonar/utils.py
+++ b/src/covsonar/utils.py
@@ -7,10 +7,19 @@ import collections
 import csv
 import os
 import sys
-from typing import Any, Dict, Generator, Iterator, List, Optional, Set, Union
+from typing import Any
+from typing import Dict
+from typing import Generator
+from typing import Iterator
+from typing import List
+from typing import Optional
+from typing import Set
+from typing import Union
 
 from Bio import SeqIO
-from Bio.SeqFeature import CompoundLocation, FeatureLocation, SeqFeature
+from Bio.SeqFeature import CompoundLocation
+from Bio.SeqFeature import FeatureLocation
+from Bio.SeqFeature import SeqFeature
 from Bio.SeqRecord import SeqRecord
 from mpire import WorkerPool
 from tqdm import tqdm


### PR DESCRIPTION
We use zimports to clean up our imports, and it wants to split these imports into separate statements. Yes it will take more vertical space but we use these tools so we don't have to think about such style decisions.