### PR TITLE
Special case for properties starting in '.', lstrip() them.

### DIFF
--- a/src/covsonar/dbm.py
+++ b/src/covsonar/dbm.py
@@ -2676,7 +2676,9 @@ class sonarDbManager:
         )
 
         # assemble sql
-        props_str = "rows." + ", rows.".join(sorted(self.properties.keys()))
+        props_str = "rows." + ", rows.".join(
+            sorted([s.lstrip(".") for s in self.properties.keys()])
+        )
         sql = f"""SELECT
                 name AS SAMPLE_NAME,
                 {props_str},


### PR DESCRIPTION
Resolves the problem of `sonar match ...` commands always causing a crash. This was caused by the `.IMPORTED` property, which because of its '.' causes problems in SQL (it seems). The '.' was already begin stripped off in some places, but not others. Added an extra lstrip() seems to fix the problem. 