### PR TITLE
Fix matching on multiple properties and profiles

### DIFF
--- a/src/covsonar/dbm.py
+++ b/src/covsonar/dbm.py
@@ -2016,7 +2016,6 @@ class sonarDbManager:
             )
 
             # Add the value to the corresponding operator set
-            val = sonarDbManager.custom_strip(val, "%")
             data[operator].append(val)
 
         # Assemble query conditions and values


### PR DESCRIPTION
Previously there would always be no matches returned when you query for > 1 property. I suspect the same would be the case if you searched for > 1 profile as well, or mixtures of the two. This fix was tested with multiple properties and profiles, as well as negation.

I don't love the `if count == 0` stuff, if you want to rewrite that in a more elegant way then feel free.