### PR TITLE
Allow lineages to also be updated from local files

### DIFF
--- a/src/covsonar/linmgr.py
+++ b/src/covsonar/linmgr.py
@@ -13,6 +13,12 @@ from typing import Optional
 import pandas as pd
 import requests
 
+from covsonar.logging import LoggingConfigurator
+
+
+# Initialize logger
+LOGGER = LoggingConfigurator.get_logger()
+
 
 class Aliasor:
     """
@@ -113,11 +119,17 @@ class sonarLinmgr:
         Download lineage and alias data.
         """
         # Download and write the lineage file
+        LOGGER.info(f"Downloading lineage info from: {self._linurl}")
         url_content = requests.get(self._linurl)
         with open(self.lineage_file, "wb") as handle:
             handle.write(url_content.content)
 
+    def download_alias_data(self):
+        """
+        Download alias data.
+        """
         # Download and write the alias file
+        LOGGER.info(f"Downloading lineage aliases info from: {self._aliurl}")
         items = requests.get(self._aliurl)
         with open(self.alias_file, "w") as handle:
             json.dump(items.json(), handle)
@@ -187,13 +199,22 @@ class sonarLinmgr:
 
         return df.sort_values(by=["lineage"])
 
-    def update_lineage_data(self) -> pd.DataFrame:
+    def update_lineage_data(self, alias_key: str, lineages: str) -> pd.DataFrame:
         """
         Update the lineage data.
 
         Returns:
             pd.DataFrame: The dataframe with updated data.
         """
-        self.download_lineage_data()
+        if alias_key:
+            self.alias_file = alias_key
+        else:
+            self.download_alias_data()
+
+        if lineages:
+            self.lineage_file = lineages
+        else:
+            self.download_lineage_data()
+
         df = self.process_lineage_data()
         return df

--- a/src/covsonar/sonar.py
+++ b/src/covsonar/sonar.py
@@ -619,6 +619,18 @@ def create_subparser_update_pangolin(
         help="download latest pangolin information",
         parents=parent_parsers,
     )
+    parser.add_argument(
+        "--alias-key",
+        help="Pangolin alias_key.json file (default: auto download from GitHub)",
+        type=str,
+        default=None,
+    )
+    parser.add_argument(
+        "--lineages",
+        help="Pangolin lineages.csv file (default: auto download from GitHub)",
+        type=str,
+        default=None,
+    )
     return subparsers, parser
 
 
@@ -930,7 +942,9 @@ def handle_update_pangolin(args: argparse.Namespace):
         FileNotFoundError: If any required files are not found.
     """
     with sonarLinmgr() as lineage_manager:
-        lineage_data = lineage_manager.update_lineage_data()
+        lineage_data = lineage_manager.update_lineage_data(
+            args.alias_key, args.lineages
+        )
 
     with sonarDbManager(args.db, readonly=False) as db_manager:
         db_manager.add_update_lineage(lineage_data)


### PR DESCRIPTION
Lately, fetching the files required to update pangolin lineage information from GitHub has been flaky and unreliable. This PR lets the user download the required files manually (`alias_key.json` and `lineages.csv`), and then update from these local files, instead of only allowing the updates from web downloads.

Also added logging output that includes the url where these files can be downloaded, in case that download fails. This lets the user know where to download the files that are needed, which can then be used to update manually.