### PR TITLE
Allow matching by seqhash (including negation with '^')

### DIFF
--- a/lib/sonardb.py
+++ b/lib/sonardb.py
@@ -1614,6 +1614,8 @@ class sonarDBManager():
 			  exclude_software_version=None,
   			  min_ct=None,
   			  max_ct=None,
+  			  include_seqhash=[],
+  			  exclude_seqhash=[],
 			  count = False,
 			  frameshifts = 0):
 
@@ -1733,6 +1735,14 @@ class sonarDBManager():
 			where_clause.append(self.get_metadata_date_condition("submission_date", *include_submission_dates))
 		if exclude_submission_dates:
 			where_clause.append(self.get_metadata_date_condition("submission_date", *exclude_submission_dates, negate=True))
+
+		## seqhash
+		if include_seqhash:
+			where_clause.append(self.get_metadata_in_condition("seqhash", *include_seqhash))
+			where_vals.extend(include_seqhash)
+		if exclude_seqhash:
+			where_clause.append(self.get_metadata_in_condition("seqhash", *exclude_seqhash, negate=True))
+			where_vals.extend(exclude_seqhash)
 
 		## profiles
 		if include_profiles:
@@ -2779,6 +2789,7 @@ class sonarDB(object):
 		software_version=None,
 		min_ct=None,
 		max_ct=None,
+		seqhashes=[],
 		ambig=False,
 		count=False,
 		frameshifts=0,
@@ -2947,6 +2958,9 @@ class sonarDB(object):
 		include_material = [x for x in materials if not str(x).startswith("^")]
 		exclude_material = [x[1:] for x in materials if str(x).startswith("^")]
 
+		include_seqhash = [x for x in seqhashes if not x.startswith("^")]
+		exclude_seqhash = [x[1:] for x in seqhashes if x.startswith("^")]
+
 		if software:
 			if not software.startswith("^"):
 				include_software = software
@@ -3070,6 +3084,8 @@ class sonarDB(object):
 					  exclude_software_version,
 		  			  min_ct,
 		  			  max_ct,
+					  include_seqhash,
+					  exclude_seqhash,
 					  count,
 					  frameshifts)
 

--- a/sonar.py
+++ b/sonar.py
@@ -77,6 +77,7 @@ def parse_args():
 	parser_match.add_argument('--material', metavar="STR", help="match genomes of the given sequencing chemistry only", type=str, nargs="+", default=[])
 	parser_match.add_argument('--min_ct', metavar="STR", help="minimal ct value of samples resulting genomes are matched to", type=float, default=None)
 	parser_match.add_argument('--max_ct', metavar="STR", help="maximal ct value of samples resulting genomes are matched to", type=float, default=None)
+	parser_match.add_argument('--seqhash', metavar="STR", help="match specific genomes with the given seqhash(es)", type=str, nargs="+", default=[])
 	parser_match_g1 = parser_match.add_mutually_exclusive_group()
 	parser_match_g1.add_argument('--count', help="count instead of listing matching genomes", action="store_true")
 	parser_match_g1.add_argument('--ambig', help="include ambiguos sites when reporting profiles (no effect when --count is used)", action="store_true")
@@ -297,8 +298,8 @@ class sonar():
 			g_after = dbm.count_genomes()
 		print(str(g_before-g_after) + " genomic entrie(s) deleted.")
 
-	def match_genomes(self, include_profiles, exclude_profiles, accessions, lineages, with_sublineage, zips, dates, submission_dates, labs, sources, collections, technologies, platforms, chemistries, software, software_version, materials, min_ct, max_ct, ambig, count=False, frameshifts=0, tsv=False):
-		rows = self.db.match(include_profiles=include_profiles, exclude_profiles=exclude_profiles, accessions=accessions, lineages=lineages, with_sublineage=with_sublineage, zips=zips, dates=dates, submission_dates=submission_dates, labs=labs, sources=sources, collections=collections, technologies=technologies, platforms=platforms, chemistries=chemistries, software=software, software_version=software_version, materials=materials, min_ct=min_ct, max_ct=max_ct, ambig=ambig, count=count, frameshifts=frameshifts, debug=debug)
+	def match_genomes(self, include_profiles, exclude_profiles, accessions, lineages, with_sublineage, zips, dates, submission_dates, labs, sources, collections, technologies, platforms, chemistries, software, software_version, materials, min_ct, max_ct, seqhash, ambig, count=False, frameshifts=0, tsv=False):
+		rows = self.db.match(include_profiles=include_profiles, exclude_profiles=exclude_profiles, accessions=accessions, lineages=lineages, with_sublineage=with_sublineage, zips=zips, dates=dates, submission_dates=submission_dates, labs=labs, sources=sources, collections=collections, technologies=technologies, platforms=platforms, chemistries=chemistries, software=software, software_version=software_version, materials=materials, min_ct=min_ct, max_ct=max_ct, seqhashes=seqhash, ambig=ambig, count=count, frameshifts=frameshifts, debug=debug)
 		if count:
 			print(rows)
 		else:
@@ -527,7 +528,7 @@ if __name__ == "__main__":
 		if args.material:
 			args.material = [x.upper() for x in args.material]
 
-		snr.match_genomes(include_profiles=args.include, exclude_profiles=args.exclude, accessions=args.acc, lineages=args.lineage, with_sublineage=args.with_sublineage, zips=args.zip, dates=args.date, submission_dates=args.submission_date, labs=args.lab, sources=args.source, collections=args.collection, technologies=args.technology, platforms=args.platform, chemistries=args.chemistry, software=args.software, software_version=args.version, materials=args.material, min_ct=args.min_ct, max_ct=args.max_ct, ambig=args.ambig, count=args.count, frameshifts=frameshifts, tsv=args.tsv)
+		snr.match_genomes(include_profiles=args.include, exclude_profiles=args.exclude, accessions=args.acc, lineages=args.lineage, with_sublineage=args.with_sublineage, zips=args.zip, dates=args.date, submission_dates=args.submission_date, labs=args.lab, sources=args.source, collections=args.collection, technologies=args.technology, platforms=args.platform, chemistries=args.chemistry, software=args.software, software_version=args.version, materials=args.material, min_ct=args.min_ct, max_ct=args.max_ct, seqhash=args.seqhash, ambig=args.ambig, count=args.count, frameshifts=frameshifts, tsv=args.tsv)
 
 	# update
 	if args.tool == "update":


### PR DESCRIPTION
Closes #102 

example:
```
$ sonar.py match --db mydb.db --seqhash ++2yklvCBObD92ROkN6haMrxtiI ++3YbhdYjBUadifd0MnnPggBfUg
```