### PR TITLE
Add covsonar 1 precommit hook to run black and zimports, etc.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.2.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+        exclude_types: [csv, tsv]
+        exclude: \.(fna|fasta|fa|gff|gff3)$
+    -   id: trailing-whitespace
+        exclude_types: [csv, tsv]
+        exclude: \.(fna|fasta|fa|gff|gff3)$
+
+-   repo: https://github.com/sqlalchemyorg/zimports
+    rev: v0.4.5
+    hooks:
+    -   id: zimports
+        args:
+        - --keep-unused-type-checking
+        - --black-line-length=79
+
+-   repo: https://github.com/python/black
+    rev: 22.3.0
+    hooks:
+    -   id: black


### PR DESCRIPTION
Doesn't use poetry like covsonar 2, but downloads the tools into a local dir so they don't need to already be installed.

Requires you to have pre-commit installed already, and then (I think) you need to run `pre-commit install` in the covsonar directory once to set everything up.